### PR TITLE
Update README badge repository name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,9 +1,9 @@
 = Acquizition
 ifdef::env-github,env-browser[:relfileprefix: docs/]
 
-https://travis-ci.org/CS2103-AY1819S2-T12-2/main[image:https://travis-ci.org/cs2103-ay1819s2-t12-2/main.svg?branch=master[Build Status]]
+https://travis-ci.org/CS2103-AY1819S2-T12-2/main[image:https://travis-ci.org/CS2103-AY1819S2-T12-2/main.svg?branch=master[Build Status]]
 https://ci.appveyor.com/project/sergiovieri/main[image:https://ci.appveyor.com/api/projects/status/ukgcotxvrf021ksr/branch/master?svg=true[Build Status]]
-https://coveralls.io/github/cs2103-ay1819s2-t12-2/main?branch=master[image:https://coveralls.io/repos/github/cs2103-ay1819s2-t12-2/main/badge.svg?branch=master[Coverage Status]]
+https://coveralls.io/github/CS2103-AY1819S2-T12-2/main?branch=master[image:https://coveralls.io/repos/github/CS2103-AY1819S2-T12-2/main/badge.svg?branch=master[Coverage Status]]
 https://www.codacy.com/app/sergiovieri/main?utm_source=github.com&utm_medium=referral&utm_content=cs2103-ay1819s2-t12-2/main&utm_campaign=Badge_Grade[image:https://api.codacy.com/project/badge/Grade/caf9760ff67c48b498d39589c74ac45a[Codacy Badge]]
 
 ifdef::env-github[]


### PR DESCRIPTION
We changed our repository name to uppercase, so we need to change the badge as well.